### PR TITLE
Implemented Result API

### DIFF
--- a/Sources/BasicExtensions/Basic.swift
+++ b/Sources/BasicExtensions/Basic.swift
@@ -67,14 +67,14 @@ public extension Decodable {
 	/// Decode data in JSON decoding
 	/// - Parameter json: JSON encoded data
 	/// - Returns: Generic Decodable value representing the JSON
-	static func from <T: Decodable> (json: Data) -> T {
-		try! JSONDecoder().decode(T.self, from: json)
+	static func from <T: Decodable> (json: Data) throws -> T {
+		try JSONDecoder().decode(T.self, from: json)
 	}
 	/// Decode data in JSON decoding
 	/// - Parameter json: JSON encoded string
 	/// - Returns: Generic Decodable value representing the JSON
-	static func from <T: Decodable> (json: String) -> T {
-		from(json: Data(json.utf8))
+	static func from <T: Decodable> (json: String) throws -> T {
+		try from(json: Data(json.utf8))
 	}
 }
 

--- a/Sources/StorageExtensions/Prefs.swift
+++ b/Sources/StorageExtensions/Prefs.swift
@@ -26,8 +26,9 @@ public final class Prefs {
 		self.filename = file
 		
 		if FileSystem.fileExists(filename),
-			let data = FileSystem.read(file: filename) {
-			dict = .from(json: data)
+			let data = FileSystem.read(file: filename),
+			let json: [String: String] = try? .from(json: data) {
+			dict = json
 		}
 	}
 	
@@ -63,7 +64,7 @@ public final class Prefs {
 	/// - Returns: some Decodable, or nil if not found
 	public func codable<Type: Decodable>(key: PrefKey) -> Type? {
 		guard let str = dict[key.value] else { return nil }
-		return .from(json: str)
+		return try? .from(json: str)
 	}
 	
 	/// check if value exists at a given key

--- a/Tests/StorageTests/PrefsTests.swift
+++ b/Tests/StorageTests/PrefsTests.swift
@@ -68,7 +68,7 @@ final class PrefsTests: XCTestCase {
 		XCTAssert(dict == prefs.codable(key: .numbers))
 		
 		afterWrite(at: prefs) { json in
-			XCTAssert(dict == .from(json: json[PrefKey.numbers.value]!))
+			XCTAssert(dict == (try! .from(json: json[PrefKey.numbers.value]!)))
 		}
 	}
 	
@@ -139,7 +139,7 @@ final class PrefsTests: XCTestCase {
 		
 		prefs.queue.async { //after written to storage
 			let data = FileSystem.read(file: prefs.filename)!
-			let json: [String: String] = .from(json: data)
+			let json: [String: String] = try! .from(json: data)
 			test(json)
 			
 			expectation.fulfill()

--- a/Tests/StorageTests/PrefsTests.swift
+++ b/Tests/StorageTests/PrefsTests.swift
@@ -145,7 +145,7 @@ final class PrefsTests: XCTestCase {
 			expectation.fulfill()
 		}
 		
-		wait(for: [expectation], timeout: 2)
+		wait(for: [expectation], timeout: 25)
 	}
 	
 	static var allTests = [


### PR DESCRIPTION
ADD
 - Generic Result enumeration
 - convenience dataTask methods with Result (Data + Generic)

CHANGE
 - made `from` methods dangerous, and change calling with `try`
 - URLRequestTests: testing `Result` methods
 - minor indentations